### PR TITLE
chore: only notify slack when we deploy a revision directly

### DIFF
--- a/index.js
+++ b/index.js
@@ -286,12 +286,10 @@ class PnConfiguration {
         return (slack) =>{
           var message;
           var revisionKey = context.revisionData.revisionKey;
-          if (revisionKey && !context.revisionData.activatedRevisionKey) {
-            message = "Deployed " + appName + " to " + process.env.DEPLOY_TARGET + " but did not activate it.\n";
-          } else {
+          if (revisionKey && context.revisionData.activatedRevisionKey) {
             message = `Deployed and activated ${appName} to ${process.env.DEPLOY_TARGET} (revision ${revisionKey})`;
+            return slack.notify(message);
           }
-          return slack.notify(message);
         };
       },
 


### PR DESCRIPTION
in our new deploy flow we prebuild and then activate without using
ember-cli-deploy, this means that we have a LOT of build messages that
are not really helpful on slack